### PR TITLE
fit 'naomi_simple' model

### DIFF
--- a/src/naomi-simple/functions.R
+++ b/src/naomi-simple/functions.R
@@ -1,21 +1,69 @@
 #' A local version of naomi::make_tmb_obj
 #' [NEEDS TO BE EDITED TO WORK WITH DLL = "naomi_simple"]
-local_make_tmb_obj <- function(data, par, calc_outputs = 0L, inner_verbose, progress, map, DLL = "naomi") {
+local_make_tmb_obj <- function(data, par, calc_outputs = 0L, inner_verbose, progress = NULL, map = NULL, DLL = "naomi_simple") {
   # Begin expose naomi:::make_tmb_obj
   # https://github.com/mrc-ide/naomi/blob/e9de40f12cf2e652f78966bb351fa5718ecd7867/R/tmb-model.R#L496
   data$calc_outputs <- as.integer(calc_outputs)
 
   integrate_out <- c(
-    "beta_rho", "beta_alpha", "beta_alpha_t2", "beta_lambda",
-    "beta_asfr", "beta_anc_rho", "beta_anc_alpha", "beta_anc_rho_t2",
-    "beta_anc_alpha_t2", "u_rho_x", "us_rho_x", "u_rho_xs",
-    "us_rho_xs", "u_rho_a", "u_rho_as", "u_rho_xa", "u_alpha_x",
-    "us_alpha_x", "u_alpha_xs", "us_alpha_xs", "u_alpha_a",
-    "u_alpha_as", "u_alpha_xt", "u_alpha_xa", "u_alpha_xat",
-    "u_alpha_xst", "ui_lambda_x", "logit_nu_raw", "ui_asfr_x",
-    "ui_anc_rho_x", "ui_anc_alpha_x", "ui_anc_rho_xt", "ui_anc_alpha_xt",
-    "log_or_gamma", "log_or_gamma_t1t2"
+    "beta_rho",
+    "beta_alpha",
+    "beta_alpha_t2",
+    "beta_lambda",
+    "beta_asfr",
+    "beta_anc_rho",
+    "beta_anc_alpha",
+    "beta_anc_rho_t2",
+    "beta_anc_alpha_t2",
+    "u_rho_x",
+    "us_rho_x",
+    "u_rho_xs",
+    "us_rho_xs",
+    "u_rho_a",
+    "u_rho_as",
+    "u_rho_xa",
+    "u_alpha_x",
+    "us_alpha_x",
+    "u_alpha_xs",
+    "us_alpha_xs",
+    "u_alpha_a",
+    "u_alpha_as",
+    "u_alpha_xt",
+    "u_alpha_xa",
+    "u_alpha_xat",
+    "u_alpha_xst",
+    "ui_lambda_x",
+    "logit_nu_raw",
+    "ui_asfr_x",
+    "ui_anc_rho_x",
+    "ui_anc_alpha_x",
+    "ui_anc_rho_xt",
+    "ui_anc_alpha_xt",
+    "log_or_gamma",
+    "log_or_gamma_t1t2"
   )
+
+  if (DLL == "naomi_simple") {
+
+    exclude_random_pars <- c(
+      "beta_alpha_t2",
+      "beta_asfr",
+      "beta_anc_rho_t2",
+      "beta_anc_alpha_t2",
+      "u_alpha_xt",
+      "u_alpha_xat",
+      "u_alpha_xst",
+      "logit_nu_raw",
+      "ui_asfr_x",
+      "ui_anc_rho_xt",
+      "ui_anc_alpha_xt",
+      "log_or_gamma_t1t2"
+    )
+
+    integrate_out <- setdiff(integrate_out, exclude_random_pars)
+    
+  }
+      
 
   if(DLL == "naomi_beta_rho_index") {
     integrate_out <- integrate_out[!integrate_out == "beta_rho"]
@@ -39,14 +87,154 @@ local_make_tmb_obj <- function(data, par, calc_outputs = 0L, inner_verbose, prog
   # End expose naomi:::make_tmb_obj
 }
 
+#' Exclude parameters and data not required by naomi_simple model
+#' 
+local_exclude_inputs <- function(tmb_inputs) {
+
+  simple_include_data <- c(
+    "population_t1",
+    "X_rho",
+    "X_alpha",
+    "X_lambda",
+    "X_ancrho",
+    "X_ancalpha",
+    "Z_x",
+    "Z_rho_x",
+    "Z_rho_xs",
+    "Z_rho_a",
+    "Z_rho_as",
+    "Z_rho_xa",
+    "Z_alpha_x",
+    "Z_alpha_xs",
+    "Z_alpha_a",
+    "Z_alpha_as",
+    "Z_alpha_xa",
+    "Z_lambda_x",
+    "Z_ancrho_x",
+    "Z_ancalpha_x",
+    "log_asfr_t1_offset",
+    "logit_anc_rho_t1_offset",
+    "logit_anc_alpha_t1_offset",
+    "logit_rho_offset",
+    "logit_alpha_offset",
+    "Q_x",
+    "Q_x_rankdef",
+    "n_nb",
+    "adj_i",
+    "adj_j",
+    "Xgamma",
+    "log_gamma_offset",
+    "Xart_idx",
+    "Xart_gamma",
+    "omega",
+    "OmegaT0",
+    "sigma_OmegaT",
+    "betaT0",
+    "sigma_betaT",
+    "ritaT",
+    "X_15to49",
+    "log_lambda_t1_offset",
+    "X_15to49f",
+    "X_paed_rho_ratio",
+    "paed_rho_ratio_offset",
+    "X_paed_lambda_ratio_t1",
+    "x_prev",
+    "n_prev",
+    "A_prev",
+    "x_artcov",
+    "n_artcov",
+    "A_artcov",
+    "x_recent",
+    "n_recent",
+    "A_recent",
+    "x_anc_prev_t1",
+    "n_anc_prev_t1",
+    "A_anc_prev_t1",
+    "x_anc_artcov_t1",
+    "n_anc_artcov_t1",
+    "A_anc_artcov_t1",
+    "A_artattend_t1",
+    "x_artnum_t1",
+    "A_artattend_mf",
+    "A_art_reside_attend",
+    "A_out",
+    "A_anc_out",
+    "calc_outputs",
+    "report_likelihood"
+  )
+
+  simple_include_par <- c(
+    "beta_rho",
+    "beta_alpha",
+    "beta_lambda",
+    "beta_anc_rho",
+    "beta_anc_alpha",
+    "u_rho_x",
+    "us_rho_x",
+    "u_rho_xs",
+    "us_rho_xs",
+    "u_rho_a",
+    "u_rho_as",
+    "u_rho_xa",
+    "ui_anc_rho_x",
+    "ui_anc_alpha_x",
+    "u_alpha_x",
+    "us_alpha_x",
+    "u_alpha_xs",
+    "us_alpha_xs",
+    "u_alpha_a",
+    "u_alpha_as",
+    "u_alpha_xa",
+    "log_sigma_lambda_x",
+    "ui_lambda_x",
+    "logit_phi_rho_a",
+    "log_sigma_rho_a",
+    "logit_phi_rho_as",
+    "log_sigma_rho_as",
+    "logit_phi_rho_x",
+    "log_sigma_rho_x",
+    "logit_phi_rho_xs",
+    "log_sigma_rho_xs",
+    "log_sigma_rho_xa",
+    "logit_phi_alpha_a",
+    "log_sigma_alpha_a",
+    "logit_phi_alpha_as",
+    "log_sigma_alpha_as",
+    "logit_phi_alpha_x",
+    "log_sigma_alpha_x",
+    "logit_phi_alpha_xs",
+    "log_sigma_alpha_xs",
+    "log_sigma_alpha_xa",
+    "OmegaT_raw",
+    "log_betaT",
+    "log_sigma_ancrho_x",
+    "log_sigma_ancalpha_x",
+    "log_or_gamma",
+    "log_sigma_or_gamma"
+  )
+
+  tmb_inputs$data <- tmb_inputs$data[simple_include_data]
+  tmb_inputs$par_init <- tmb_inputs$par_init[simple_include_par]
+
+  class(tmb_inputs) <- "naomi_simple_tmb_input"
+
+  tmb_inputs
+}
+
+
 #' A local version of naomi::fit_tmb
 #' [NEEDS TO BE EDITED TO WORK WITH DLL = "naomi_simple"]
-local_fit_tmb <- function(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE, max_iter = 250, progress = NULL, map = NULL) {
+local_fit_tmb <- function(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE, max_iter = 250, progress = NULL, map = NULL, DLL = "naomi") {
   # Begin expose naomi::fit_tmb
   # https://github.com/mrc-ide/naomi/blob/e9de40f12cf2e652f78966bb351fa5718ecd7867/R/tmb-model.R#L557
-  stopifnot(inherits(tmb_input, "naomi_tmb_input"))
 
-  obj <- local_make_tmb_obj(tmb_input$data, tmb_input$par_init, calc_outputs = 0L, inner_verbose, progress, map)
+  if (DLL == "naomi_simple") {
+    stopifnot(inherits(tmb_input, "naomi_simple_tmb_input"))
+  } else {
+    stopifnot(inherits(tmb_input, "naomi_tmb_input"))
+  }
+
+  obj <- local_make_tmb_obj(tmb_input$data, tmb_input$par_init, calc_outputs = 0L, inner_verbose, progress, map, DLL = DLL)
   data <- tmb_input$data
   par <- tmb_input$par_init
   calc_outputs <- 0L
@@ -66,7 +254,7 @@ local_fit_tmb <- function(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE
 
   f$par.fixed <- f$par
   f$par.full <- obj$env$last.par
-  objout <- naomi:::make_tmb_obj(tmb_input$data, tmb_input$par_init, calc_outputs = 1L, inner_verbose)
+  objout <- local_make_tmb_obj(tmb_input$data, tmb_input$par_init, calc_outputs = 1L, inner_verbose, DLL = DLL)
   f$mode <- objout$report(f$par.full)
   val <- c(f, obj = list(objout))
   class(val) <- "naomi_fit"

--- a/src/naomi-simple/naomi_simple.cpp
+++ b/src/naomi-simple/naomi_simple.cpp
@@ -70,7 +70,6 @@ Type objective_function<Type>::operator() ()
   DATA_MATRIX(X_alpha);
   DATA_MATRIX(X_lambda);
 
-  DATA_MATRIX(X_asfr);
   DATA_MATRIX(X_ancrho);
   DATA_MATRIX(X_ancalpha);
 
@@ -84,10 +83,7 @@ Type objective_function<Type>::operator() ()
   DATA_SPARSE_MATRIX(Z_alpha_xs);
   DATA_SPARSE_MATRIX(Z_alpha_a);
   DATA_SPARSE_MATRIX(Z_alpha_as);
-  DATA_SPARSE_MATRIX(Z_alpha_xt);
   DATA_SPARSE_MATRIX(Z_alpha_xa);
-  DATA_SPARSE_MATRIX(Z_alpha_xat);
-  DATA_SPARSE_MATRIX(Z_alpha_xst);
 
   DATA_SPARSE_MATRIX(Z_x);
   DATA_SPARSE_MATRIX(Z_lambda_x);
@@ -101,7 +97,6 @@ Type objective_function<Type>::operator() ()
 
   DATA_VECTOR(logit_anc_alpha_t1_offset);
 
-  DATA_SPARSE_MATRIX(Z_asfr_x);
   DATA_SPARSE_MATRIX(Z_ancrho_x);
   DATA_SPARSE_MATRIX(Z_ancalpha_x);
 
@@ -117,10 +112,6 @@ Type objective_function<Type>::operator() ()
   DATA_VECTOR(n_artcov);
   DATA_VECTOR(x_artcov);
   DATA_SPARSE_MATRIX(A_artcov);
-
-  DATA_VECTOR(n_vls);
-  DATA_VECTOR(x_vls);
-  DATA_SPARSE_MATRIX(A_vls);
 
   DATA_VECTOR(n_recent);
   DATA_VECTOR(x_recent);
@@ -158,8 +149,6 @@ Type objective_function<Type>::operator() ()
   DATA_SCALAR(betaT0);
   DATA_SCALAR(sigma_betaT);
   DATA_SCALAR(ritaT);
-  DATA_SCALAR(logit_nu_mean);
-  DATA_SCALAR(logit_nu_sd);
 
   DATA_SPARSE_MATRIX(X_15to49);
   DATA_VECTOR(log_lambda_t1_offset);
@@ -188,9 +177,6 @@ Type objective_function<Type>::operator() ()
 
   PARAMETER_VECTOR(beta_lambda);
   val -= dnorm(beta_lambda, 0.0, 5.0, true).sum();
-
-  PARAMETER_VECTOR(beta_asfr);
-  val -= dnorm(beta_asfr, 0.0, 5.0, true).sum();
 
   PARAMETER_VECTOR(beta_anc_rho);
   val -= dnorm(beta_anc_rho, 0.0, 5.0, true).sum();
@@ -308,21 +294,9 @@ Type objective_function<Type>::operator() ()
   Type sigma_alpha_as(exp(log_sigma_alpha_as));
   val -= dnorm(sigma_alpha_as, Type(0.0), Type(2.5), true) + log_sigma_alpha_as;
 
-  PARAMETER(log_sigma_alpha_xt);
-  Type sigma_alpha_xt(exp(log_sigma_alpha_xt));
-  val -= dnorm(sigma_alpha_xt, Type(0.0), Type(2.5), true) + log_sigma_alpha_xt;
-
   PARAMETER(log_sigma_alpha_xa);
   Type sigma_alpha_xa(exp(log_sigma_alpha_xa));
   val -= dnorm(sigma_alpha_xa, Type(0.0), Type(2.5), true) + log_sigma_alpha_xa;
-
-  PARAMETER(log_sigma_alpha_xat);
-  Type sigma_alpha_xat(exp(log_sigma_alpha_xat));
-  val -= dnorm(sigma_alpha_xat, Type(0.0), Type(2.5), true) + log_sigma_alpha_xat;
-
-  PARAMETER(log_sigma_alpha_xst);
-  Type sigma_alpha_xst(exp(log_sigma_alpha_xst));
-  val -= dnorm(sigma_alpha_xst, Type(0.0), Type(2.5), true) + log_sigma_alpha_xst;
 
   PARAMETER_VECTOR(u_alpha_x);
   PARAMETER_VECTOR(us_alpha_x);
@@ -344,18 +318,10 @@ Type objective_function<Type>::operator() ()
   if(u_alpha_as.size() > 0)
     val += SCALE(AR1(phi_alpha_as), sigma_alpha_as)(u_alpha_as);
 
-  PARAMETER_VECTOR(u_alpha_xt);
-  val -= dnorm(u_alpha_xt, 0.0, sigma_alpha_xt, true).sum();
-
   PARAMETER_VECTOR(u_alpha_xa);
   val -= dnorm(u_alpha_xa, 0.0, sigma_alpha_xa, true).sum();
 
-  PARAMETER_VECTOR(u_alpha_xat);
-  val -= dnorm(u_alpha_xat, 0.0, sigma_alpha_xat, true).sum();
-
-  PARAMETER_VECTOR(u_alpha_xst);
-  val -= dnorm(u_alpha_xst, 0.0, sigma_alpha_xst, true).sum();
-
+  
   // * HIV incidence model *
 
   PARAMETER(OmegaT_raw);
@@ -366,10 +332,6 @@ Type objective_function<Type>::operator() ()
   val -= dnorm(exp(log_betaT), Type(0.0), Type(1.0), true) + log_betaT;
   Type betaT = betaT0 + exp(log_betaT) * sigma_betaT;
 
-  PARAMETER(logit_nu_raw);
-  val -= dnorm(logit_nu_raw, Type(0.0), Type(1.0), true);
-  Type nu = invlogit(logit_nu_mean + logit_nu_raw * logit_nu_sd);
-
   PARAMETER(log_sigma_lambda_x);
   Type sigma_lambda_x(exp(log_sigma_lambda_x));
   val -= dnorm(sigma_lambda_x, Type(0.0), Type(1.0), true) + log_sigma_lambda_x;
@@ -377,15 +339,8 @@ Type objective_function<Type>::operator() ()
   PARAMETER_VECTOR(ui_lambda_x);
   val -= sum(dnorm(ui_lambda_x, 0.0, sigma_lambda_x, true));
 
+  
   // * ANC testing model *
-
-  // district ASFR random effects
-  PARAMETER(log_sigma_asfr_x);
-  Type sigma_asfr_x(exp(log_sigma_asfr_x));
-  val -= dnorm(sigma_asfr_x, Type(0.0), Type(2.5), true) + log_sigma_asfr_x;
-
-  PARAMETER_VECTOR(ui_asfr_x);
-  val -= sum(dnorm(ui_asfr_x, 0.0, sigma_asfr_x, true));
 
   // ANC prevalence and ART coverage random effects
   PARAMETER(log_sigma_ancrho_x);
@@ -401,20 +356,6 @@ Type objective_function<Type>::operator() ()
 
   PARAMETER_VECTOR(ui_anc_alpha_x);
   val -= sum(dnorm(ui_anc_alpha_x, 0.0, sigma_ancalpha_x, true));
-
-  PARAMETER(log_sigma_ancrho_xt);
-  Type sigma_ancrho_xt(exp(log_sigma_ancrho_xt));
-  val -= dnorm(sigma_ancrho_xt, Type(0.0), Type(2.5), true) + log_sigma_ancrho_xt;
-
-  PARAMETER(log_sigma_ancalpha_xt);
-  Type sigma_ancalpha_xt(exp(log_sigma_ancalpha_xt));
-  val -= dnorm(sigma_ancalpha_xt, Type(0.0), Type(2.5), true) + log_sigma_ancalpha_xt;
-
-  PARAMETER_VECTOR(ui_anc_rho_xt);
-  val -= sum(dnorm(ui_anc_rho_xt, 0.0, sigma_ancrho_xt, true));
-
-  PARAMETER_VECTOR(ui_anc_alpha_xt);
-  val -= sum(dnorm(ui_anc_alpha_xt, 0.0, sigma_ancalpha_xt, true));
 
 
   // * ART attendance model *
@@ -490,9 +431,6 @@ Type objective_function<Type>::operator() ()
   vector<Type> hhs_artcov_ll = dbinom(x_artcov, n_artcov, alpha_obs_t1, true);
   val -= sum(hhs_artcov_ll);
 
-  vector<Type> vls_obs_t1(nu * (A_vls * artnum_t1) / (A_vls * plhiv_t1));
-  val -= dbinom(x_vls, n_vls, vls_obs_t1, true).sum();
-
   vector<Type> pR_infections_obs_t1(A_recent * infections_t1);
   vector<Type> pR_plhiv_obs_t1(A_recent * plhiv_t1);
   vector<Type> pR_population_obs_t1(A_recent * population_t1);
@@ -510,9 +448,6 @@ Type objective_function<Type>::operator() ()
   //       of female age 15-49 age groups. But I don't know if it would be
   //       meaningfully more efficient.
 
-  vector<Type> mu_asfr(X_asfr * beta_asfr +
-    Z_asfr_x * ui_asfr_x);
-
   vector<Type> mu_anc_rho_t1(mu_rho +
     logit_anc_rho_t1_offset +
     X_ancrho * beta_anc_rho +
@@ -525,7 +460,8 @@ Type objective_function<Type>::operator() ()
     Z_ancalpha_x * ui_anc_alpha_x);
   vector<Type> anc_alpha_t1(invlogit(mu_anc_alpha_t1));
 
-  vector<Type> anc_clients_t1(population_t1 * exp(log_asfr_t1_offset + mu_asfr));
+  // JE NOTE 6 Jan 2022: removed mu_asfr term -- should not use for aggregate ANC.
+  vector<Type> anc_clients_t1(population_t1 * exp(log_asfr_t1_offset));
   vector<Type> anc_plhiv_t1(anc_clients_t1 * anc_rho_t1);
   vector<Type> anc_already_art_t1(anc_plhiv_t1 * anc_alpha_t1);
 
@@ -570,10 +506,6 @@ Type objective_function<Type>::operator() ()
   DATA_INTEGER(calc_outputs);
   DATA_INTEGER(report_likelihood)
 
-  // Proportion unaware among the untreated population
-  // Fixed input from Spectrum
-  DATA_VECTOR(unaware_untreated_prop_t1);
-
   if(calc_outputs) {
 
     vector<Type> population_t1_out(A_out * population_t1);
@@ -591,11 +523,6 @@ Type objective_function<Type>::operator() ()
     vector<Type> plhiv_attend_ij_t1((Xart_idx * plhiv_t1) * (Xart_gamma * gamma_art_t1));
     vector<Type> plhiv_attend_t1_out(A_out * (A_artattend_mf * plhiv_attend_ij_t1));
     vector<Type> untreated_plhiv_attend_t1_out(plhiv_attend_t1_out - artattend_t1_out);
-
-    vector<Type> unaware_plhiv_num_t1((plhiv_t1 - artnum_t1) * unaware_untreated_prop_t1);
-    vector<Type> unaware_plhiv_num_t1_out(A_out * unaware_plhiv_num_t1);
-    vector<Type> aware_plhiv_num_t1_out(plhiv_t1_out - unaware_plhiv_num_t1_out);
-    vector<Type> aware_plhiv_prop_t1_out(aware_plhiv_num_t1_out / plhiv_t1_out);
 
     vector<Type> infections_t1_out(A_out * infections_t1);
     vector<Type> lambda_t1_out(infections_t1_out / (population_t1_out - plhiv_t1_out));
@@ -625,9 +552,6 @@ Type objective_function<Type>::operator() ()
     REPORT(untreated_plhiv_num_t1_out);
     REPORT(plhiv_attend_t1_out);
     REPORT(untreated_plhiv_attend_t1_out);
-    REPORT(aware_plhiv_prop_t1_out);
-    REPORT(aware_plhiv_num_t1_out);
-    REPORT(unaware_plhiv_num_t1_out);
     REPORT(lambda_t1_out);
     REPORT(infections_t1_out);
     REPORT(anc_clients_t1_out);
@@ -671,25 +595,18 @@ Type objective_function<Type>::operator() ()
   REPORT(log_sigma_alpha_a)
   REPORT(logit_phi_alpha_as)
   REPORT(log_sigma_alpha_as)
-  REPORT(log_sigma_alpha_xt)
   REPORT(log_sigma_alpha_xa)
-  REPORT(log_sigma_alpha_xat)
-  REPORT(log_sigma_alpha_xst)
   REPORT(OmegaT_raw)
   REPORT(log_betaT)
   REPORT(log_sigma_lambda_x)
-  REPORT(log_sigma_asfr_x)
   REPORT(log_sigma_ancrho_x)
   REPORT(log_sigma_ancalpha_x)
-  REPORT(log_sigma_ancrho_xt)
-  REPORT(log_sigma_ancalpha_xt)
   REPORT(log_sigma_or_gamma)
 
   // Latent field
   REPORT(beta_rho)
   REPORT(beta_alpha)
   REPORT(beta_lambda)
-  REPORT(beta_asfr)
   REPORT(beta_anc_rho)
   REPORT(beta_anc_alpha)
   REPORT(u_rho_x)
@@ -705,17 +622,10 @@ Type objective_function<Type>::operator() ()
   REPORT(us_alpha_xs)
   REPORT(u_alpha_a)
   REPORT(u_alpha_as)
-  REPORT(u_alpha_xt)
   REPORT(u_alpha_xa)
-  REPORT(u_alpha_xat)
-  REPORT(u_alpha_xst)
   REPORT(ui_lambda_x)
-  REPORT(logit_nu_raw)
-  REPORT(ui_asfr_x)
   REPORT(ui_anc_rho_x)
   REPORT(ui_anc_alpha_x)
-  REPORT(ui_anc_rho_xt)
-  REPORT(ui_anc_alpha_xt)
   REPORT(log_or_gamma)
 
   return val;

--- a/src/naomi-simple/script.R
+++ b/src/naomi-simple/script.R
@@ -63,12 +63,12 @@ naomi_data <- select_naomi_data(
 #' Naomi with packageVersion("naomi"), and if required, install version 2.8.5.
 #' with devtools::install_github("mrc-ide/naomi", ref = "e9de40f")
 
-compile("naomi.cpp")
-dyn.load(dynlib("naomi"))
+## compile("naomi.cpp")
+## dyn.load(dynlib("naomi"))
 
 #' Want to replace the above with
-# compile("naomi_simple.cpp")
-# dyn.load(dynlib("naomi_simple"))
+compile("naomi_simple.cpp")
+dyn.load(dynlib("naomi_simple"))
 
 #' The replace all of the following fitting, uncertainty generation, and model output
 #' with equivalent versions using naomi_simple rather than naomi. The end state should
@@ -76,8 +76,11 @@ dyn.load(dynlib("naomi"))
 #' assuming that removing projection does not change the estimates at the time of survey
 #' (and that indicators below corresponds to T1 not T2 or T3 say).
 
+tmb_inputs <- prepare_tmb_inputs(naomi_data)
+tmb_inputs_simple <- local_exclude_inputs(tmb_inputs)
+
 #' Fit TMB model
-fit <- local_fit_tmb(tmb_inputs, outer_verbose = TRUE, inner_verbose = FALSE, max_iter = 250, progress = NULL)
+fit <- local_fit_tmb(tmb_inputs_simple, outer_verbose = TRUE, inner_verbose = FALSE, max_iter = 250, progress = NULL, DLL = "naomi_simple")
 
 #' Add uncertainty
 fit <- local_sample_tmb(fit, nsample = 2000)

--- a/src/naomi-simple/script.R
+++ b/src/naomi-simple/script.R
@@ -86,7 +86,7 @@ fit <- local_fit_tmb(tmb_inputs_simple, outer_verbose = TRUE, inner_verbose = FA
 fit <- local_sample_tmb(fit, nsample = 2000)
 
 #' Calculate model outputs
-outputs <- output_package(fit, naomi_data)
+outputs <- local_output_package_naomi_simple(fit, naomi_data)
 
 indicators <- add_output_labels(outputs) %>%
   left_join(outputs$meta_area %>% select(area_level, area_id, center_x, center_y)) %>%


### PR DESCRIPTION
This PR:

* Removes extraneous data and parameters from `naomi_simple.cpp`.
* Creates a new function `local_exclude_inputs()` to update a `tmb_input` object to remove the data and parameters that are not used in `naomi_simple.cpp`
  * The `prepare_naomi_data()` and `prepare_tmb_inputs()` functions are left unchanged, so they are doing a lot of extraneous work. But I think not worth the effort to create custom versions of them now. Can revisit later if it becomes so.
* Update `fit_tmb()` to accept `DLL = "naomi_simple"` argument.
* Add version of `local_output_package_naomi_simple()` that only produces T1 outputs for `naomi_simple`.